### PR TITLE
Reveal during commit phase

### DIFF
--- a/packages/client/src/layers/frontend/phaser/systems/createResetSystem.ts
+++ b/packages/client/src/layers/frontend/phaser/systems/createResetSystem.ts
@@ -62,15 +62,16 @@ export function createResetSystem(phaser: PhaserLayer) {
       }
     }
 
-    // AFTER DELAY: reveal moves
+    // START OF PHASE: reveal moves
+    // note: contract-side this occurs during the commit phase
     if (phase == Phase.Reveal) {
-      // AFTER DELAY
-      if (timeToNextPhase == gameConfig.revealPhaseLength - DELAY) {
-        const lastMove = getComponentValue(LastMove, playerEntity)?.value;
-        if (lastMove == turn) return;
-        const encoding = getComponentValue(CommittedMoves, GodEntityIndex)?.value;
-        if (encoding) revealMove(encoding);
-      }
+      // adding a two second delay so the last-second commitment can execute before this
+      if (timeToNextPhase !== gameConfig.revealPhaseLength - 2) return;
+
+      const lastMove = getComponentValue(LastMove, playerEntity)?.value;
+      if (lastMove == turn) return;
+      const encoding = getComponentValue(CommittedMoves, GodEntityIndex)?.value;
+      if (encoding) revealMove(encoding);
     }
 
     // START OF PHASE: clear move commitments

--- a/packages/contracts/src/systems/MoveSystem.sol
+++ b/packages/contracts/src/systems/MoveSystem.sol
@@ -37,6 +37,11 @@ contract MoveSystem is System {
       (uint256[], uint256[], uint256)
     );
 
+    require(
+      LibTurn.getCurrentPhase(components) != Phase.Action,
+      "MoveSystem: cannot complete move during Action phase"
+    );
+
     uint256 playerEntity = addressToEntity(msg.sender);
 
     require(
@@ -50,7 +55,6 @@ contract MoveSystem is System {
     require(LibUtils.playerIdExists(components, playerEntity), "MoveSystem: player does not exist");
 
     LastMoveComponent lastMoveComponent = LastMoveComponent(getAddressById(components, LastMoveComponentID));
-    require(LibTurn.getCurrentPhase(components) == Phase.Reveal, "MoveSystem: incorrect turn phase");
 
     uint32 currentTurn = LibTurn.getCurrentTurn(components);
     require(lastMoveComponent.getValue(playerEntity) < currentTurn, "MoveSystem: already moved this turn");


### PR DESCRIPTION
This is for user experience -- before you had to wait until 5 seconds left in move execution before they were automatically executed. Now it happens automatically.